### PR TITLE
Clearer instructions on database usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Write your queries in `normal_cars.sql` when instructed to.
 
 1. Create a new postgres user named `normal_user`.
 1. Create a new database named `normal_cars` owned by `normal_user`.
+1. Run the provided `scripts/denormal_data.sql` script on the `normal_cars` database.
 1. Whiteboard your solution to normalizing the `denormal_cars` schema.
 1. [bonus] Generate a diagram (somehow) in .png (or other) format, that of your normalized cars schema. (save and commit to this repo).
 1. In `normal_cars.sql` Create a query to generate the tables needed to accomplish your normalized schema, including any primary and foreign key constraints. Logical renaming of columns is allowed.
-1. Using the resources that you now possess, In `normal_cars.sql` Create queries to insert **all** of the data that was in the `denormal_cars.car_models` table, into the new normalized tables of the `normal_cars` database.
+1. Using the resources that you now possess, In `normal_cars.sql` Create queries to insert **all** of the data that was in the `car_models` table, into the new normalized tables of the `normal_cars` database.
 1. In `normal_cars.sql` Create a query to get a list of all `make_title` values in the `car_models` table. Without any duplicate rows, this should have 71 results.
 1. In `normal_cars.sql` Create a query to list all `model_title` values where the `make_code` is `'VOLKS'` Without any duplicate rows, this should have 27 results.
 1. In `normal_cars.sql` Create a query to list all `make_code`, `model_code`, `model_title`, and year from `car_models` where the `make_code` is `'LAM'`. Without any duplicate rows, this should have 136 rows.


### PR DESCRIPTION
In the second half of the exercise, the instructions imply that data should be moved from the `denormal_cars` database to the `normal_cars` database. This is incorrect. The `denormal_data` dataset should be inserted into the `normal_cars` database like the first half of the exercise and the data should be moved from the `car_models` table into the newly created normalized tables.